### PR TITLE
Add dependencies

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -19,7 +19,11 @@ BugReports: https://github.com/learnB4SS/learnB4SS/issues
 Imports: brms,
     glue,
     usethis,
-    utils
+    utils, 
+    tidybayes,
+    bayestestR,
+    parameters,
+    see
 Suggests: 
     learnr,
     knitr,


### PR DESCRIPTION
@stefanocoretta Is this how I can include `tidybayes`, `bayestestR`, `parameters`, and `see` so that they will be installed when `learnB4SS` is installed? Using this PR to start the conversation, but I think this is wrong :/