### PR TITLE
add missing dependency

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -26,7 +26,10 @@ URL: https://github.com/learnB4SS/learnB4SS
 BugReports: https://github.com/learnB4SS/learnB4SS/issues
 Imports: brms,
     bayestestR,
+    dplyr,
+    ggplot2,
     glue,
+    here, 
     parameters,
     patchwork,
     see,


### PR DESCRIPTION
I saw the pkgdown job failed because of the missing dependencies. I added them to the DESCRIPTION file, but now I think I get why you said to just keep all eval=F (cause then you don't need those dependencies). I'm creating this PR, but I'm not merging. I'll leave this up to you. 